### PR TITLE
Add color color schemes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Noah Rhodes"]
 version = "0.1.0"
 
 [deps]
+ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
@@ -22,6 +23,7 @@ VegaLite = "112f6efa-9a02-5b7d-90c0-432ed331239a"
 
 [compat]
 Colors = "~0.12"
+ColorSchemes = "~3"
 DataFrames = "~0.21, ~0.22"
 GeometryBasics = "~0.3"
 InfrastructureModels = "~0.5, ~0.6"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
 PowerPlots = "229d1e32-5c67-4c9a-a884-d6a3a7f23cfa"

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -33,20 +33,40 @@ Aliases exist override all node and edge sizes.
 powerplot(data, node_size=1000, edge_size=10)
 ```
 
-## Color Schemes and System Data
-The color can be set to a range, and a data value can be associated with each element.  Here, the color range for buses is from gray to red, and the data shown is the votlage angle.
+## System Data
+Component data values from the PowerModels dictionary can be plotted by specfying the dictionary key.
 
 ```@example power_data
-p = powerplot(data, bus_data="va", bus_data_type="quantitative", bus_color=["gray","red"])
+p = powerplot(data, bus_data="va", bus_data_type="quantitative")
 ```
 
 ```@example power_data
 p = powerplot(data, branch_data="index",
                     branch_data_type="nominal",
-                    branch_color=["green","yellow"],
+                    gen_data="pmax",
+                    gen_data_type="quantitative",
+)
+```
+
+### Color Schemes
+Color ranges are automatically interpolated from a range that is provided.  If only a single color is given, the component will not change color based on the data.
+
+```@example power_data
+p = powerplot(data,
                     gen_data="pmax",
                     gen_data_type="quantitative",
                     gen_color=["#232323","#AAFAFA"]
+)
+```
+
+Color schemes from the package `ColorSchemes.jl` can also be used to specify a color range.
+
+```@example power_data
+using ColorSchemes
+powerplot(data;
+            gen_data=:pmax,
+            gen_color=colorscheme2array(ColorSchemes.colorschemes[:summer]),
+            gen_data_type=:quantitative
 )
 ```
 

--- a/src/PowerPlots.jl
+++ b/src/PowerPlots.jl
@@ -7,6 +7,7 @@ import LinearAlgebra
 
 import VegaLite
 import Colors
+import ColorSchemes
 import DataFrames
 import Memento
 
@@ -25,8 +26,8 @@ _IM = InfrastructureModels
 include("core/configuration.jl")
 include("core/types.jl")
 include("core/data.jl")
-include("core/options.jl")
 include("core/utils.jl")
+include("core/options.jl")
 include("core/attribute_validation.jl")
 
 include("plots/plot.jl")
@@ -35,6 +36,8 @@ include("layouts/common.jl")
 include("layouts/layout_engines.jl")
 
 include("graph/common.jl")
+
+include("experimental/experimental.jl")
 
 include("core/export.jl")  # must be last to properly export all functions
 

--- a/src/core/attribute_validation.jl
+++ b/src/core/attribute_validation.jl
@@ -10,11 +10,11 @@ function _validate_plot_attributes!(plot_attributes::Dict{Symbol, Any})
     # validate color attributes
     for attr in _color_attributes
         color = plot_attributes[attr]
-        if !(typeof(color) <: Union{String, Symbol, Vector})
+        if !(typeof(color) <: Union{String, Symbol, AbstractVector})
           Memento.warn(_LOGGER, "Color value for $(repr(attr)) should be given as symbol or string")
         else
           try
-            if typeof(color) <: Vector
+            if typeof(color) <: AbstractVector
                 parse.(Colors.Colorant, color) # parses all colors as CSS color
             else
                 parse(Colors.Colorant, color) # try to parse the color as a CSS color

--- a/src/core/options.jl
+++ b/src/core/options.jl
@@ -1,11 +1,23 @@
+# Default Color Schemes
+# catergory 20b and 20c used as reference
+const color_schemes=Dict{Symbol,Any}(
+    :blues => colorscheme2array(ColorSchemes.ColorScheme(range(Colors.colorant"#3182BD", Colors.colorant"#C6DBEF", length=5))),#["#$(Colors.hex(c))" for c in ColorSchemes.ColorScheme(range(Colors.colorant"#3182BD", Colors.colorant"#C6DBEF", length=5))],
+    :greens => colorscheme2array(ColorSchemes.ColorScheme(range(Colors.colorant"#31A354", Colors.colorant"#C7E9C0", length=5))),
+    :oranges => colorscheme2array(ColorSchemes.ColorScheme(range(Colors.colorant"#E6550D", Colors.colorant"#FDD0A2", length=5))),
+    :reds => colorscheme2array(ColorSchemes.ColorScheme(range(Colors.colorant"#843C39", Colors.colorant"#E7969C", length=5))),
+    :purples => colorscheme2array(ColorSchemes.ColorScheme(range(Colors.colorant"#756BB1", Colors.colorant"#DADAEB", length=5))),
+
+)
+
+
 # Default plot attributes
-const default_plot_attributes = Dict{Symbol, Any}(
-  :gen_color => [:blue],
-  :bus_color => [:green],
-  :branch_color => [:black],
+default_plot_attributes = Dict{Symbol, Any}(
+  :gen_color => color_schemes[:oranges],
+  :bus_color => color_schemes[:greens],
+  :branch_color => color_schemes[:blues],
   :connector_color => [:gray],
-  :dcline_color => [:CadetBlue],
-  :storage_color => [:steelblue],
+  :dcline_color => color_schemes[:purples],
+  :storage_color => color_schemes[:oranges],
   :gen_size => 5e2,
   :bus_size => 5e2,
   :branch_size => 5,

--- a/src/core/utils.jl
+++ b/src/core/utils.jl
@@ -80,3 +80,9 @@ push!(_EXCLUDE_SYMBOLS, Symbol("@prepare_plot_attributes"))
 
 #   # Rest of plotting code...
 # end
+
+
+"Convert a color scheme `cs` into an array of string hex colors, usable by VegaLite"
+function colorscheme2array(cs::ColorSchemes.ColorScheme)
+    return a = ["#$(Colors.hex(c))" for c in cs]
+end

--- a/src/experimental/experimental.jl
+++ b/src/experimental/experimental.jl
@@ -1,0 +1,51 @@
+
+module Experimental
+    using VegaLite, ColorSchemes
+
+    ## set branch color scheme after graph is created.  This does not currently function because the layer numbers are may
+    # not correlate if a device does not exist (e.g. dclines)
+    function set_branch_color_range(plot::VegaLite.VLSpec, cs::ColorSchemes.ColorScheme)
+        return set_branch_color_range(plot, colorscheme2array(cs))
+    end
+
+    function set_branch_color_range(plot::VegaLite.VLSpec, cr::AbstractVector{String})
+        return plot.layer[1]["encoding"]["color"]["scale"]["range"] = cr
+    end
+
+
+    function set_connector_color_range(plot::VegaLite.VLSpec, cs::ColorSchemes.ColorScheme)
+        return set_connector_color_range(plot, colorscheme2array(cs))
+    end
+
+    function set_connector_color_range(plot::VegaLite.VLSpec, cr::AbstractVector{String})
+        return plot.layer[2]["encoding"]["color"]["scale"]["range"] = cr
+    end
+
+    # function set_dcline_color_range(plot::VegaLite.VLSpec, cs::ColorSchemes.ColorScheme)
+    #   return set_dcline_color_range(plot, colorscheme2array(cs))
+    # end
+
+    # function set_dcline_color_range(plot::VegaLite.VLSpec, cr::AbstractVector{String})
+    #   return plot.layer[3]["encoding"]["color"]["scale"]["range"] = cr
+    # end
+
+
+    function set_bus_color_range(plot::VegaLite.VLSpec, cs::ColorSchemes.ColorScheme)
+        return set_bus_color_range(plot, colorscheme2array(cs))
+    end
+
+    function set_bus_color_range(plot::VegaLite.VLSpec, cr::AbstractVector{String})
+        return plot.layer[3]["encoding"]["color"]["scale"]["range"] = cr
+    end
+
+
+
+    function set_gen_color_range(plot::VegaLite.VLSpec, cs::ColorSchemes.ColorScheme)
+        return set_gen_color_range(plot, colorscheme2array(cs))
+    end
+
+    function set_gen_color_range(plot::VegaLite.VLSpec, cr::AbstractVector{String})
+        return plot.layer[4]["encoding"]["color"]["scale"]["range"] = cr
+    end
+
+end


### PR DESCRIPTION
Default device colors now come with a color range.  Now when some one tries to use data for a component, they see a difference without also having to add a color range.

Also added the feature to be able to use color schemes from ColorSchemes as color ranges.

Added experimental module to separate experimental features from working features.  Added functions like `set_gen_color_range(plot,color_scheme)` here.  This is experimental because the layer ids are not consistent and a fix is needed to make this work properly when not all devices are present (like DC lines or storage).