### PR TITLE
Update documenter interactivity

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -16,3 +16,6 @@ VegaLite = "112f6efa-9a02-5b7d-90c0-432ed331239a"
 [compat]
 PowerModels = "^0.19.2, ^0.20, ^0.21"
 PowerModelsDistribution = "^0.14.5, ^0.15, ^0.16"
+
+[sources]
+VegaLite = {url = "https://github.com/noahrhodes/VegaLite.jl", rev = "fix_443"}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -14,5 +14,5 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 VegaLite = "112f6efa-9a02-5b7d-90c0-432ed331239a"
 
 [compat]
-PowerModels = "^0.19.2"
-PowerModelsDistribution = "^0.14.5, ^0.15"
+PowerModels = "^0.19.2, ^0.20, ^0.21"
+PowerModelsDistribution = "^0.14.5, ^0.15, ^0.16"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,11 @@ end
 makedocs(
     warnonly = true,
     modules = [PowerPlots],
-    format = Documenter.HTML(mathengine = Documenter.MathJax()),
+    format = Documenter.HTML(mathengine = Documenter.MathJax(),
+        size_threshold_warn = 2^20,
+        size_threshold = nothing,
+        example_size_threshold = nothing,
+    ),  
     sitename = "PowerPlots",
     authors = "Noah Rhodes",
     pages = [


### PR DESCRIPTION
Update documentation to support interactivity again.

Requires https://github.com/queryverse/VegaLite.jl/pull/451 to be merged and tagged.