### PR TITLE
Feature added linestyle

### DIFF
--- a/docs/src/examples/basic examples.md
+++ b/docs/src/examples/basic examples.md
@@ -71,7 +71,7 @@ p = powerplot(data, width=300, height=300,
 ```
 
 # Branch line styles 
-The line style of branches can be customized by using `branch_linestyle_rules`. This setting lets you define which columns in the branch data determine the line style and how specific values in that column map to selected styles. The length of `branch_linestyle_labels` must be equal to the number of defined rules plus one.
+The line style of branches can be customized by using `branch_linestyle_rules`. This setting lets you define which columns in the branch data determine the line style and how specific values in that column map to selected styles. The length of `branch_linestyle_labels` must be equal to the number of defined rules plus the one which defines default. The dash pattern `[stroke, space]` sets the `strokeDash` parameter in Vega, which determines the line style. See [Vega Line Mark documentation](https://vega.github.io/vega/docs/marks/line/) for further information.
 
 ```@example power_data
 # add new columns to branch data

--- a/docs/src/examples/basic examples.md
+++ b/docs/src/examples/basic examples.md
@@ -70,6 +70,35 @@ p = powerplot(data, width=300, height=300,
 )
 ```
 
+# Branch line styles 
+The line style of branches can be customized by using `branch_linestyle_rules`. This setting lets you define which columns in the branch data determine the line style and how specific values in that column map to selected styles. The length of `branch_linestyle_labels` must be equal to the number of defined rules plus one.
+
+```@example power_data
+# add new columns to branch data
+PST_list=[0,0,1,0,0,0,0]
+for (key, subdict) in data["branch"]
+    subdict["pst"] = PST_list[parse(Int,key)]
+    subdict["loading"] = rand(1:100)
+end
+
+p = PowerPlots.powerplot(data,
+    branch=(
+        :data=>"loading", 
+        :data_type=>"quantitative",
+        :color=>reverse(colorscheme2array(ColorSchemes.colorschemes[:RdYlGn_4])),
+        :branch_linestyle_rules => [
+            (:transformer, Dict(true=>[2,2])),
+            (:pst, Dict(1=>[6,3])),
+        ],
+        :branch_linestyle_labels => ["Line", "Transformer", "PST"],
+        :show_linestyle_legend => true,
+    )
+)
+p.layer[1]["layer"][1]["encoding"]["color"]["scale"]["domain"]=[0,100]
+p.layer[1]["layer"][1]["encoding"]["color"]["legend"]=Dict("title"=>"Loading (%)")
+display(p)
+```
+
 # Specify components for plotting
 Default supported components for plotting are specified as:
 ```@example power_data

--- a/docs/src/parameters.md
+++ b/docs/src/parameters.md
@@ -24,6 +24,7 @@ There are several component 'toggle' parameters that control whether certain dis
 | ------- | ----------- | ------- |
 | `show_flow` | whether flow arrows are displayed | `false` |
 | `show_flow_legend` | whether the legend for the flow arrows is shown | `false` |
+| `show_linestyle_legend` | whether the legend for the branch linestyles is shown | `false` |
 
 ### Color
 The color arguments can accept several inputs.  A single color can be specified using a color name as a symbol or a string.  [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) names are supported.  In addition, hex color values in a string are supported.
@@ -124,3 +125,6 @@ powerplot(case; gen_data=:index, gen_data_type=:nominal) # the index is a discre
 | Keyword     | Description | Default |
 | ----------- | ----------- | ------- |
 | `:connector_dash`     | set dash size for connectors | `[4,4]` |
+| `branch_linestyle_rules`     | define rules for branch linestyles | `[]` |
+| `default_branch_linestyle`     | set the default branch dash size | `[1,0]` |
+| `branch_linestyle_labels`     | set labels for linestyles in the legend | `nothing` |

--- a/src/core/options.jl
+++ b/src/core/options.jl
@@ -56,7 +56,11 @@ default_edge_attributes = Dict{Symbol,Any}(
     :flow_arrow_size_range => [500, 3000],
     :show_flow => false,
     :show_flow_legend => false,
-    :hover => nothing
+    :hover => nothing,
+    :default_branch_linestyle => [1,0],
+    :branch_linestyle_rules => [],
+    :branch_linestyle_labels => nothing,
+    :show_linestyle_legend => false,
 )
 
 default_connector_attributes = Dict{Symbol,Any}(


### PR DESCRIPTION
First of all, thank  you for this very helpful package! I added a new feature, which I needed. If you have any suggestions or feedback on how the implementation could be improved, I’d greatly appreciate it.

### Added linestyle feature
**Description**
- feature to change the dash pattern of selected branches
- the selection of branches is based on a given column (can be multiple) in the branch data (`branch_linestyle_rules`)
- in the selected column the defined value leads to a costum linestyle of the branch
- the line style is defined by the `strokeDash` parameter of Vega

**Changes**
- added description in Documentary
- added `default_branch_linestyle` , `branch_linestyle_rules` , `branch_linestyle_labels` , `show_linestyle_legend` parameters
- adjusted `plot_edge` and added `assign_branchstyle!`

**Example**
```
# add new columns to branch data
PST_list=[0,0,1,0,0,0,0]
for (key, subdict) in data["branch"]
    subdict["pst"] = PST_list[parse(Int,key)]
    subdict["loading"] = rand(1:100)
end

p = PowerPlots.powerplot(data,
    branch=(
        :data=>"loading", 
        :data_type=>"quantitative",
        :color=>reverse(colorscheme2array(ColorSchemes.colorschemes[:RdYlGn_4])),
        :branch_linestyle_rules => [
            (:transformer, Dict(true=>[2,2])),
            (:pst, Dict(1=>[6,3])),
        ],
        :branch_linestyle_labels => ["Line", "Transformer", "PST"],
        :show_linestyle_legend => true,
    )
)
p.layer[1]["layer"][1]["encoding"]["color"]["scale"]["domain"]=[0,100]
p.layer[1]["layer"][1]["encoding"]["color"]["legend"]=Dict("title"=>"Loading (%)")
display(p)
```
![image](https://github.com/user-attachments/assets/ac0aaa73-dd99-4757-b512-63ca6f3a828b)
