### PR TITLE
Update parameter docs

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
@@ -14,9 +15,9 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 VegaDatasets = "0ae4a718-28b7-58ec-9efb-cded64d6d5b4"
 VegaLite = "112f6efa-9a02-5b7d-90c0-432ed331239a"
 
+[sources]
+VegaLite = {rev = "fix_443", url = "https://github.com/noahrhodes/VegaLite.jl"}
+
 [compat]
 PowerModels = "^0.19.2, ^0.20, ^0.21"
 PowerModelsDistribution = "^0.14.5, ^0.15, ^0.16"
-
-[sources]
-VegaLite = {url = "https://github.com/noahrhodes/VegaLite.jl", rev = "fix_443"}

--- a/docs/src/data_transformations/powermodelsgraphs.md
+++ b/docs/src/data_transformations/powermodelsgraphs.md
@@ -47,9 +47,9 @@ PowerModelsGraph(data::Dict{String,<:Any},
 There is also a convenient function with default node and edge types as keyword arguments that include all the default supported components.
 ```julia
 PowerModelsGraph(data::Dict{String,<:Any},
-                node_components=supported_node_types,
-                edge_components=supported_edge_types,
-                connected_components=supported_connected_types
+                node_components=default_node_types,
+                edge_components=default_edge_types,
+                connected_components=default_connected_types
 )
 ```
 

--- a/docs/src/examples/basic examples.md
+++ b/docs/src/examples/basic examples.md
@@ -73,15 +73,15 @@ p = powerplot(data, width=300, height=300,
 # Specify components for plotting
 Default supported components for plotting are specified as:
 ```@example power_data
-supported_connected_types
+default_connected_types
 ```
 
 ```@example power_data
-supported_node_types
+default_node_types
 ```
 
 ```@example power_data
-supported_edge_types
+default_edge_types
 ```
 
 

--- a/docs/src/parameters.md
+++ b/docs/src/parameters.md
@@ -7,120 +7,183 @@ These parameters modify the entire plot.
 | ----------- | ----------- | ------- |
 | `width`     | width of the plot in pixels | `500` |
 | `height`    | height of the plot in pixels | `500` |
-| `layout_algorithim` | algorithm for generating network layout (see [Layouts](@ref)) | `kamada_kawai` |
+| `layout_algorithm` | algorithm for generating network layout (see [Layouts](@ref)) | `kamada_kawai` |
 | `fixed` | use fixed coordinates from network model | `false` |
 | `parallel_edge_offset` | offset distance between parallel edges | `0.05` |
-| `components` | string array of components to plot | `supported_component_types`|
+| `node_components` | string or symbol array of node components to plot | `default_node_types`|
+| `edge_components` | string or symbol array of edge components to plot | `default_edge_types`|
+| `connected_components` | string or symbol array of connected components to plot | `default_connected_types`|
 
-
-
+The current set of default component types includes:
+```@example
+using PowerPlots #hide
+default_node_types
+```
+```@example
+using PowerPlots #hide
+default_edge_types
+```
+```@example
+using PowerPlots #hide
+default_connected_types
+```
 
 ## Component Parameters
 These parameters modify a specific component.
-### Toggles
-There are several component 'toggle' parameters that control whether certain display properties of components are on or off. These accept boolean values.
-
-| Keyword | Description | Default |
-| ------- | ----------- | ------- |
-| `show_flow` | whether flow arrows are displayed | `false` |
-| `show_flow_legend` | whether the legend for the flow arrows is shown | `false` |
 
 ### Color
-The color arguments can accept several inputs.  A single color can be specified using a color name as a symbol or a string.  [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) names are supported.  In addition, hex color values in a string are supported.
+The `:color` argument can accept several inputs.  A single color can be specified using a color name as a symbol or a string.  [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) names are supported.  In addition, hex color values in a string are supported.
 
 ```julia
-powerplot(case; branch_color=:yellow)
-powerplot(case; branch_color="yellow")
-powerplot(case; branch_color="#FFA71A")
+powerplot(case; branch=(:color=:yellow))
+powerplot(case; branch=(:color="yellow"))
+powerplot(case; branch=(:color="#FFA71A"))
 ```
 
 A color range can be created by using several colors in an array. The range is used when component data is specified.
 
 ```julia
-powerplot(case; branch_color=[:red, "yellow", "#0000FF"])
+powerplot(case; branch=(:color=>[:red, "yellow", "#0000FF"]))
 ```
 
 A color scheme from `ColorSchemes.jl` can be used, but the ColorScheme must be converted to an array of colors that can be interpreted by VegaLite.
 
 ```julia
 using ColorSchemes
-powerplot(case; branch_color=colorscheme2array(ColorSchemes.colorschemes[:tableau_10]))
+powerplot(case; branch=(:color=>colorscheme2array(ColorSchemes.colorschemes[:tableau_10])))
 ```
 
-| Keyword     | Description | Default |
-| ----------- | ----------- | ------- |
-| `branch_color`    | set the color of a branch | `["#3182BD", "#5798CA", "#7CAED6", "#A0C5E2", "#C6DBEF"]` |
-| `dcline_color`    | set the color of a DC line | `["#756BB1", "#8F87C0", "#A8A3CE", "#C0BEDC", "#DADAEB"]` |
-| `switch_color`    | set the color of a switch | `["#555555", "#808080", "#AAAAAA", "#D4D4D4", "#FFFFFF"]` |
-| `transformer_color`    | set the color of a transformer | `["#8C6D31", "#A3854A", "#B99C63", "#D0B37B", "#E7CB94"]` |
-| `connector_color`    | set the color of a connector | `[:gray]` |
-| `gen_color`       |  set the color of a generator | `["#E6550D", "#EB7433", "#F19358", "#F8B17C", "#FDD0A2"]` |
-| `bus_color`       |  set the color of a bus | `["#31A354", "#57B46F", "#7CC68A", "#A1D8A5", "#C7E9C0"]` |
-| `load_color`      |  set the color of a load | `["#843C39", "#9D5352", "#B5696B", "#CE7F83", "#E7969C"]` |
-| `node_color`      |  set the color of all buses and generators | N/A |
-| `edge_color`      |  set the color of all branches, DC lines, and connectors | N/A|
-| `flow_color`      | set the color of flow arrows | `:black`
+Default colors are determined by the order the components are plotted, shown in the legend.  The default color profiles are:
+
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[1]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[2]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[3]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[4]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[5]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[6]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[7]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[8]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[9]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[10]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[11]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[12]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[13]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[14]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[15]]) # hide
+```
+```@example
+using PowerPlots, Colors # hide
+parse.(Colorant, color_schemes[component_color_order[16]]) # hide
+```
+
+### Flow
+Power flow can be shown on edges of the network.  For each edge component, the following parameters are available:
+
+| Keyword | Description | Default |
+| ------- | ----------- | ------- |
+| `show_flow` | whether flow arrows representing 'pt' are displayed on edges | `false` |
+| `show_flow_legend` | whether the legend for the flow arrows is shown | `false` |
+
+```@example power_data
+powerplot(case; branch=(:show_flow=>true, :show_flow_legend=>true))
+```
 
 
 ### Size
-The size argument sets the size of a component.  The size does not vary with data in the base plot.
+The `:size` argument sets the size of a component.  The size does not vary with data in the base plot.
 
-| Keyword     | Description | Default |
+| Component     | Description | Default |
 | ----------- | ----------- | ------- |
-| `branch_size`     | set the size of a branch | `5` |
-| `dcline_size`    | set the size of a DC line | `5` |
-| `transformer_size`    | set the size of a transformer | `5` |
-| `switch_size`    | set the size of a switch | `5` |
-| `connector_size`    | set the size of a connector | `3` |
-| `gen_size`    |  set the size of a generator | `500` |
-| `bus_size`    |  set the size of a bus | `500` |
-| `load_size`    |  set the size of a load | `500` |
-| `node_size`    |  set the size of all buses and generators | N/A |
-| `edge_size`    |  set the size of all branches, DC lines, and connectors | N/A |
-| `flow_arrow_size_range` | set size range for power flow arrows | `[500,3000]` |
-
-### Data
-The data argument selects the data from the component dictionary to use in the visualization.  The data argument can be a string or a symbol.  The data value modifies the color of a component based on the color range.
+| `edge`     | default size of all edges except connector | `5` |
+| `connector`    | default size of connector | `3` |
+| `node`    |  set the size of all nodes | `500` |
 
 ```julia
-powerplot(case; gen_data=:pmax)
-powerplot(case; gen_data=:pmin)
+powerplot(case; branch=(:size=>10), gen=(:size=>250))
 ```
 
-| Keyword     | Description | Default |
-| ----------- | ----------- | ------- |
-| `branch_data`     | set the data of a branch | `"ComponentType"` |
-| `dcline_data`     | set the data of a DC line | `"ComponentType"` |
-| `switch_data`     | set the data of a switch | `"ComponentType"` |
-| `transformer_data`    | set the data of a transformer | `"ComponentType"` |
-| `connector_data`    | set the data of a connector | `"ComponentType"` |
-| `gen_data`        |  set the data of a generator | `"ComponentType"` |
-| `bus_data`        |  set the data of a bus | `"ComponentType"` |
-| `load_data`       |  set the data of a load | `"ComponentType"` |
+
+The size of the flow arrows is a keyword that is a subset of the edge it models. However, the only first plotted component in the legend will use the `flow_arrow_size_range` keyword.  All subsequent components will use the same range as the first.
+```julia
+powerplot(case;
+    branch=(:show_flow=>true, :show_flow_legend=>true,
+     :flow_arrow_size_range=>[100,500]),
+    switch=(:show_flow=>true, :show_flow_legend=>true,
+     :flow_arrow_size_range=>[500,3000])
+)
+```
+
+
+### Data
+The `:data` argument selects the data from the component dictionary to use in the visualization.  The data argument can be a string or a symbol.  The data value modifies the color of a component based on the color range.
+
+```julia
+powerplot(case; gen(:data=:pmax))
+powerplot(case; gen(:data=:pmin))
+```
 
 
 ### Datatype
-The datatypes in [VegaLite](https://vega.github.io/vega-lite/docs/type.html) can be `:nominal`, `:ordinal`, or `:quantintative`.  `:nominal` and `:ordinal` are both discrete values, and `:quantitative` is continuous.  In the context of the simple `powerplot`, there is no distinction between `:nominal` and `:ordinal`.
+The datatypes in [VegaLite](https://vega.github.io/vega-lite/docs/type.html) can be `:nominal`, `:ordinal`, or `:quantintative`.  `:nominal` and `:ordinal` are both discrete values, and `:quantitative` is continuous.  In the context of the simple `powerplot`, there is no distinction between `:nominal` and `:ordinal`.  The default data type is `nominal`.
 
 ```julia
-powerplot(case; gen_data=:pg, gen_data_type=:quantitative) # the pg is continous, so use a continous scale
-powerplot(case; gen_data=:index, gen_data_type=:nominal) # the index is a discrete value, so use a discrete scale
+powerplot(case; gen(:data=:pg, :data_type=:quantitative)) # the pg is continous, so use a continous scale
+powerplot(case; gen(:data=:index, :data_type=:nominal)) # the index is a discrete value, so use a discrete scale
 ```
 
-| Keyword     | Description | Default |
-| ----------- | ----------- | ------- |
-| `branch_data_type`     | set the datatype of a branch | `:nominal` |
-| `dcline_data_type`    | set the datatype of a DC line | `:nominal` |
-| `switch_data_type`    | set the datatype of a switch | `:nominal` |
-| `transformer_data_type`    | set the datatype of a transformer | `:nominal` |
-| `connector_data_type`    | set the datatype of a connector | `:nominal` |
-| `gen_data_type`    |  set the datatype of a generator | `:nominal` |
-| `bus_data_type`    |  set the datatype of a bus | `:nominal` |
-| `load_data_type`    |  set the datatype of a load | `:nominal` |
-
-
 ### Other Parameters
+The length of the dashes on the connector lines can be controlled with the `:dash` keyword.
+The value is a two element array, with the first term representing the length of the gap and the second term representing the length of the dash.
 
 | Keyword     | Description | Default |
 | ----------- | ----------- | ------- |
-| `:connector_dash`     | set dash size for connectors | `[4,4]` |
+| `:dash`     | set dash size for connectors | `[4,4]` |
+
+```julia
+powerplot(case, connector = (:dash=>[2,2]))
+powerplot(case, connector = (:dash=>[2,8]))
+```

--- a/src/core/data.jl
+++ b/src/core/data.jl
@@ -1,6 +1,6 @@
 
 "return a Dict indexed by bus pairs, with a value of an array of tuples of edge types and edge ids of parallel edges"
- function get_parallel_edges(data, edge_types=supported_edge_types)
+ function get_parallel_edges(data, edge_types=default_edge_types)
     edge_pairs = Dict()
     for edge_type in edge_types # supported edge_types
         for (id,edge) in get(data, string(edge_type), Dict())
@@ -27,7 +27,7 @@
 end
 
 "Add x/y coords for all any parallel branches, and offset the endpoints so each branch is visible"
-function offset_parallel_edges!(data,offset; edge_types=supported_edge_types)
+function offset_parallel_edges!(data,offset; edge_types=default_edge_types)
     get_parallel_edges(data, edge_types)
     for (bus_pair, edges) in get_parallel_edges(data, edge_types)
         n_edges = length(edges)

--- a/src/core/options.jl
+++ b/src/core/options.jl
@@ -42,9 +42,9 @@ default_plot_attributes = Dict{Symbol,Any}(
     :width => 500,
     :height => 500,
     :parallel_edge_offset => 0.05,
-    :node_components => supported_node_types,
-    :edge_components => supported_edge_types,
-    :connected_components => supported_connected_types,
+    :node_components => default_node_types,
+    :edge_components => default_edge_types,
+    :connected_components => default_connected_types,
 )
 
 default_edge_attributes = Dict{Symbol,Any}(

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -1,8 +1,8 @@
 
 
-const supported_connected_types = [:gen,:load,:storage,:generator,:voltage_source,:solar,:shunt]
-const supported_node_types = [:bus]
-const supported_edge_types = [:branch,:dcline,:switch,:transformer,:line]
+const default_connected_types = [:gen,:load,:storage,:generator,:voltage_source,:solar,:shunt]
+const default_node_types = [:bus]
+const default_edge_types = [:branch,:dcline,:switch,:transformer,:line]
 
 """
     PowerModelsGraph
@@ -101,9 +101,9 @@ end
 
 ""
 function PowerModelsGraph(data::Dict{String,<:Any};
-    node_components=supported_node_types::Union{AbstractVector{Symbol}, AbstractVector{String}},
-    edge_components=supported_edge_types::Union{AbstractVector{Symbol}, AbstractVector{String}},
-    connected_components=supported_connected_types::Union{AbstractVector{Symbol}, AbstractVector{String}},
+    node_components=default_node_types::Union{AbstractVector{Symbol}, AbstractVector{String}},
+    edge_components=default_edge_types::Union{AbstractVector{Symbol}, AbstractVector{String}},
+    connected_components=default_connected_types::Union{AbstractVector{Symbol}, AbstractVector{String}},
     )
     if eltype(node_components) == String
         node_components = Symbol.(node_components)
@@ -200,7 +200,7 @@ mutable struct PowerModelsDataFrame
     end
 end
 
-function PowerModelsDataFrame(case::Dict{String,<:Any}; components::Vector{<:Any}=vcat(supported_node_types,supported_edge_types,supported_connected_types))
+function PowerModelsDataFrame(case::Dict{String,<:Any}; components::Vector{<:Any}=vcat(default_node_types,default_edge_types,default_connected_types))
     return PowerModelsDataFrame(case, Symbol[Symbol(i) for i in components])
 end
 

--- a/src/layouts/common.jl
+++ b/src/layouts/common.jl
@@ -40,9 +40,9 @@ and `edge_types`.  A layout function is then applied, by default `layout_graph_k
 components is returned.
 """
 function layout_network!(data::Dict{String,<:Any};
-    node_components::AbstractArray{Symbol,1} = supported_node_types,
-    edge_components::AbstractArray{Symbol,1} = supported_edge_types,
-    connected_components::AbstractArray{Symbol,1} = supported_connected_types,
+    node_components::AbstractArray{Symbol,1} = default_node_types,
+    edge_components::AbstractArray{Symbol,1} = default_edge_types,
+    connected_components::AbstractArray{Symbol,1} = default_connected_types,
     fixed::Bool = false,
     layout_algorithm = kamada_kawai,
     connector_weight::Union{Nothing, AbstractFloat}=nothing,

--- a/src/plots/plot.jl
+++ b/src/plots/plot.jl
@@ -14,9 +14,9 @@ Create a plower plot. Check github repo for documentation on kwarg options.
 function powerplot(
     case::Dict{String,<:Any};
     layout_algorithm=kamada_kawai,
-    edge_components=supported_edge_types,
-    node_components=supported_node_types,
-    connected_components=supported_connected_types,
+    edge_components=default_edge_types,
+    node_components=default_node_types,
+    connected_components=default_connected_types,
     fixed=false,
     kwargs...)
 
@@ -91,9 +91,9 @@ used to plot geographic map data underneath a power grid.
 """
 function powerplot!(plt_layer::VegaLite.VLSpec, case::Dict{String,<:Any};
     layout_algorithm=kamada_kawai,
-    edge_components=supported_edge_types,
-    node_components=supported_node_types,
-    connected_components=supported_connected_types,
+    edge_components=default_edge_types,
+    node_components=default_node_types,
+    connected_components=default_connected_types,
     fixed=false,
     kwargs...)
 
@@ -161,9 +161,9 @@ end
 
 function _powerplot_mn(case::Dict{String,<:Any};
     layout_algorithm=kamada_kawai,
-    edge_components=supported_edge_types,
-    node_components=supported_node_types,
-    connected_components=supported_connected_types,
+    edge_components=default_edge_types,
+    node_components=default_node_types,
+    connected_components=default_connected_types,
     fixed=false,
     kwargs...)
 
@@ -228,9 +228,9 @@ end
 
 function _powerplot_mn!(plt_layer::VegaLite.VLSpec, case::Dict{String,<:Any};
     layout_algorithm=kamada_kawai,
-    edge_components=supported_edge_types,
-    node_components=supported_node_types,
-    connected_components=supported_connected_types,
+    edge_components=default_edge_types,
+    node_components=default_node_types,
+    connected_components=default_connected_types,
     fixed=false,
     kwargs...)
 


### PR DESCRIPTION
Parameter documentation was not updated for v0.5.  

Update documentation to match code.

Also rename:
-  `supported_connected_types` -> `default_connected_types`
-  `supported_node_types` -> `default_node_types`
-  `supported_edge_types` -> `default_edge_types`